### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.802.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.OpenSearch.Data/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.OpenSearch.Data/Extensions/ApplicationBuilderExtensions.cs
@@ -26,10 +26,10 @@ public static class ApplicationBuilderExtensions
             var documentTypes = configurations.Select(c => c.DocumentType).Distinct();
             var options = serviceProvider.GetRequiredService<IOptions<SearchOptions>>().Value;
 
-            if (options.Provider.EqualsInvariant(name))
+            if (options.Provider.EqualsIgnoreCase(name))
             {
                 var otherProviderDocumentTypes = options.DocumentScopes
-                    .Where(x => !string.IsNullOrEmpty(x.Provider) && !x.Provider.EqualsInvariant(name))
+                    .Where(x => !string.IsNullOrEmpty(x.Provider) && !x.Provider.EqualsIgnoreCase(name))
                     .Select(x => x.DocumentType);
 
                 documentTypes = documentTypes.Except(otherProviderDocumentTypes, StringComparer.OrdinalIgnoreCase);
@@ -37,7 +37,7 @@ public static class ApplicationBuilderExtensions
             else
             {
                 var currentProviderDocumentTypes = options.DocumentScopes
-                    .Where(x => x.Provider.EqualsInvariant(name))
+                    .Where(x => x.Provider.EqualsIgnoreCase(name))
                     .Select(x => x.DocumentType);
 
                 documentTypes = documentTypes.Intersect(currentProviderDocumentTypes, StringComparer.OrdinalIgnoreCase);

--- a/src/VirtoCommerce.OpenSearch.Data/OpenSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.OpenSearch.Data/OpenSearchRequestBuilder.cs
@@ -25,7 +25,7 @@ public class OpenSearchRequestBuilder
             result.Sort = GetSorting(request.Sorting);
             result.From = request.Skip;
             result.Size = request.Take;
-            result.TrackScores = request.Sorting?.Any(x => x.FieldName.EqualsInvariant(Score)) ?? false;
+            result.TrackScores = request.Sorting?.Any(x => x.FieldName.EqualsIgnoreCase(Score)) ?? false;
 
             if (request.IncludeFields?.Any() == true)
             {
@@ -95,7 +95,7 @@ public class OpenSearchRequestBuilder
                 Order = geoSorting.IsDescending ? SortOrder.Descending : SortOrder.Ascending,
             };
         }
-        else if (field.FieldName.EqualsInvariant(Score))
+        else if (field.FieldName.EqualsIgnoreCase(Score))
         {
             result = new FieldSort
             {
@@ -189,8 +189,8 @@ public class OpenSearchRequestBuilder
     {
         var termValues = termFilter.Values;
 
-        var field = availableFields.Where(kvp => kvp.Key.Name.EqualsInvariant(termFilter.FieldName)).Select(kvp => kvp.Value).FirstOrDefault();
-        if (field?.Type?.EqualsInvariant(FieldType.Boolean.ToString()) == true)
+        var field = availableFields.Where(kvp => kvp.Key.Name.EqualsIgnoreCase(termFilter.FieldName)).Select(kvp => kvp.Value).FirstOrDefault();
+        if (field?.Type?.EqualsIgnoreCase(FieldType.Boolean.ToString()) == true)
         {
             termValues = termValues.Select(v => v switch
             {
@@ -340,7 +340,7 @@ public class OpenSearchRequestBuilder
     {
         return availableFields
             .Any(kvp =>
-                kvp.Key.Name.EqualsInvariant(fieldName) &&
+                kvp.Key.Name.EqualsIgnoreCase(fieldName) &&
                 kvp.Value is KeywordProperty keywordProperty &&
                 keywordProperty.Fields?.ContainsKey("raw") == true);
     }

--- a/src/VirtoCommerce.OpenSearch.Data/VirtoCommerce.OpenSearch.Data.csproj
+++ b/src/VirtoCommerce.OpenSearch.Data/VirtoCommerce.OpenSearch.Data.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    
     <PackageReference Include="OpenSearch.Client" Version="1.8.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.876.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.807.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.OpenSearch.Web/VirtoCommerce.OpenSearch.Web.csproj
+++ b/src/VirtoCommerce.OpenSearch.Web/VirtoCommerce.OpenSearch.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.OpenSearch.Web/module.manifest
+++ b/src/VirtoCommerce.OpenSearch.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.OpenSearch</id>
-  <version>3.802.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.876.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.807.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
   </dependencies>
 
   <title>Open Search</title>
@@ -27,7 +27,7 @@
   <moduleType>VirtoCommerce.OpenSearch.Web.Module, VirtoCommerce.OpenSearch.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2025 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2025-2026 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.OpenSearch.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.OpenSearch.Tests/SearchProviderTestsBase.cs
@@ -160,7 +160,7 @@ namespace VirtoCommerce.OpenSearch.Tests
 
             if (response?.Aggregations?.Count > 0)
             {
-                result = response.Aggregations.SingleOrDefault(a => a.Id.EqualsInvariant(aggregationId));
+                result = response.Aggregations.SingleOrDefault(a => a.Id.EqualsIgnoreCase(aggregationId));
             }
 
             return result;

--- a/tests/VirtoCommerce.OpenSearch.Tests/VirtoCommerce.OpenSearch.Tests.csproj
+++ b/tests/VirtoCommerce.OpenSearch.Tests/VirtoCommerce.OpenSearch.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.OpenSearch_3.1000.0-pr-2-9402.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to runtime/framework upgrade and dependency version bumps, which can introduce build/runtime incompatibilities despite minimal functional code changes.
> 
> **Overview**
> Updates the module to target **.NET 10** across `VirtoCommerce.OpenSearch.Data`, `VirtoCommerce.OpenSearch.Web`, and test projects, and bumps the module/package versions to the `3.1000.x` line (including `VirtoCommerce.Platform.Data` and `VirtoCommerce.SearchModule.Core`).
> 
> Replaces `EqualsInvariant` comparisons with `EqualsIgnoreCase` in provider selection, request building (sorting/fields), and test aggregation lookups, keeping comparisons case-insensitive while aligning with updated platform/common APIs. Also updates test tooling packages (`coverlet.collector`, `FluentAssertions`) and refreshes `module.manifest` metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94021044605700987d7e11bce26322d10fcaac5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->